### PR TITLE
Fix colcon build error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/px4_offboard
+script_dir=$base/lib/px4_offboard
 [install]
-install-scripts=$base/lib/px4_offboard
+install_scripts=$base/lib/px4_offboard


### PR DESCRIPTION
Error occurred on setuptools
UserWarning: Usage of dash-separated will not be supported in future versions

Change dash to underscore in setup.cfg (still not available in setuptools==64.4.0, but in 58.2.0)