### PR TITLE
Launch Offboard for Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Add the repository to the ros2 workspace
 git clone https://github.com/Jaeyoung-Lim/px4-offboard.git
 ```
 
+If you are running this on a companion computer to PX4, you will need to build the package on the companion computer directly. 
+
 ## Running
+
+### Software in the Loop
 You will make use of 3 different terminals to run the offboard demo.
 
 On the first terminal, run a SITL instance from the PX4 Autopilot firmware.
@@ -39,4 +43,22 @@ ros2 launch px4_offboard offboard_position_control.launch.py
 In order to just run the visualizer,
 ```
 ros2 launch px4_offboard visualize.launch.py
+```
+### Hardware
+
+This section is intended for running the offboard control node on a companion computer, such as a Raspberry Pi or Nvidia Jetson/Xavier. You will either need an SSH connection to run this node, or have a shell script to run the nodes on start up. 
+
+If you are running this through a UART connection into the USB port, start the micro-ros agent with the following command
+
+```
+micro-ros-agent serial --dev /dev/ttyUSB0 -b 921600 -v
+```
+If you are using a UART connection which goes into the pinouts on the board, start the micro-ros agent with the following comand
+```
+micro-ros-agent serial --dev /dev/ttyTHS1 -b 921600 -V
+```
+
+To run the offboard position control example, run the node on the companion computer
+```
+ros2 launch px4_offboard offboard_hardware_position_control.launch.py
 ```

--- a/launch/offboard_hardware_position_control.launch.py
+++ b/launch/offboard_hardware_position_control.launch.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+############################################################################
+#
+#   Copyright (C) 2022 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+__author__ = "Jaeyoung Lim"
+__contact__ = "jalim@ethz.ch"
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+import os
+
+
+def generate_launch_description():
+    package_dir = get_package_share_directory('px4_offboard')
+    return LaunchDescription([
+        Node(
+            package='px4_offboard',
+            namespace='px4_offboard',
+            executable='offboard_control',
+            name='control'
+        )
+    ])

--- a/launch/offboard_position_control.launch.py
+++ b/launch/offboard_position_control.launch.py
@@ -47,7 +47,20 @@ def generate_launch_description():
         Node(
             package='px4_offboard',
             namespace='px4_offboard',
+            executable='visualizer',
+            name='visualizer'
+        ),
+        Node(
+            package='px4_offboard',
+            namespace='px4_offboard',
             executable='offboard_control',
             name='control'
+        ),
+        Node(
+            package='rviz2',
+            namespace='',
+            executable='rviz2',
+            name='rviz2',
+            arguments=['-d', [os.path.join(package_dir, 'visualize.rviz')]]
         )
     ])

--- a/launch/offboard_position_control.launch.py
+++ b/launch/offboard_position_control.launch.py
@@ -47,20 +47,7 @@ def generate_launch_description():
         Node(
             package='px4_offboard',
             namespace='px4_offboard',
-            executable='visualizer',
-            name='visualizer'
-        ),
-        Node(
-            package='px4_offboard',
-            namespace='px4_offboard',
             executable='offboard_control',
             name='control'
-        ),
-        Node(
-            package='rviz2',
-            namespace='',
-            executable='rviz2',
-            name='rviz2',
-            arguments=['-d', [os.path.join(package_dir, 'visualize.rviz')]]
         )
     ])

--- a/px4_offboard/offboard_control.py
+++ b/px4_offboard/offboard_control.py
@@ -94,7 +94,7 @@ class OffboardControl(Node):
             trajectory_msg = TrajectorySetpoint()
             trajectory_msg.position[0] = self.radius * np.cos(self.theta)
             trajectory_msg.position[1] = self.radius * np.sin(self.theta)
-            trajectory_msg.position[2] = -3.0
+            trajectory_msg.position[2] = -1.0
             self.publisher_trajectory.publish(trajectory_msg)
 
             self.theta = self.theta + self.omega * self.dt

--- a/px4_offboard/offboard_control.py
+++ b/px4_offboard/offboard_control.py
@@ -68,9 +68,10 @@ class OffboardControl(Node):
         self.timer = self.create_timer(timer_period, self.cmdloop_callback)
 
         self.nav_state = VehicleStatus.NAVIGATION_STATE_MAX
+        self.arming_state = VehicleStatus.ARMING_STATE_DISARMED
         self.dt = timer_period
         self.theta = 0.0
-        self.radius = 10.0
+        self.radius = 1.0
         self.omega = 0.5
  
     def vehicle_status_callback(self, msg):
@@ -78,6 +79,7 @@ class OffboardControl(Node):
         print("NAV_STATUS: ", msg.nav_state)
         print("  - offboard status: ", VehicleStatus.NAVIGATION_STATE_OFFBOARD)
         self.nav_state = msg.nav_state
+        self.arming_state = msg.arming_state
 
     def cmdloop_callback(self):
         # Publish offboard control modes
@@ -87,12 +89,12 @@ class OffboardControl(Node):
         offboard_msg.velocity=False
         offboard_msg.acceleration=False
         self.publisher_offboard_mode.publish(offboard_msg)
-        if self.nav_state == VehicleStatus.NAVIGATION_STATE_OFFBOARD:
+        if (self.nav_state == VehicleStatus.NAVIGATION_STATE_OFFBOARD and self.arming_state == VehicleStatus.ARMING_STATE_ARMED):
 
             trajectory_msg = TrajectorySetpoint()
             trajectory_msg.position[0] = self.radius * np.cos(self.theta)
             trajectory_msg.position[1] = self.radius * np.sin(self.theta)
-            trajectory_msg.position[2] = -5.0
+            trajectory_msg.position[2] = -3.0
             self.publisher_trajectory.publish(trajectory_msg)
 
             self.theta = self.theta + self.omega * self.dt


### PR DESCRIPTION
Add instructions for launching the offboard position control node on hardware such as a companion computer, for test flight.
Changes include:
- Commands to run the micro ros agent on serial onboard companion computer
- Launch file for running position control node on companion computer
- Modified code to ensure that the first circle is used only when the vehicle is armed