### PR TITLE
Add automatic path clear on SITL restart (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,27 @@ To run the offboard position control example, run the node on the companion comp
 ```
 ros2 launch px4_offboard offboard_hardware_position_control.launch.py
 ```
+
+### Visualization parameters
+
+The following section describes ROS2 parameters that alter behavior of visualization tool.
+
+
+#### Automatic path clearing between consequent simulation runs
+
+Running visualization node separately from the simulation can be desired to iteratively test how variety of PX4 (or custom offboard programs) parameters adjustments influence the system behavior. 
+
+In such case RVIZ2 is left opened and in separate shell simulation is repeadetly restarted. This process causes paths from consequent runs to overlap with incorrect path continuity where end of previous path is connected to the beginning of new path from new run. To prevent that and clear old path automatically on start of new simulation, set `path_clearing_timeout` to positive float value which corresponds to timeout seconds after which, upon starting new simulation, old path is removed.
+
+As an example, setting the parameter to `1.0` means that one second of delay between position updates through ROS2 topic will schedule path clearing right when next position update comes in (effectively upon next simulation run).
+
+
+To enable automatic path clearing without closing visualization node set the param to positive floating point value:
+```
+ros2 param set /px4_offboard/visualizer path_clearing_timeout 1.0
+```
+
+To disable this feature set timeout to any negative floating point value (the feature is disabled by default):
+```
+ros2 param set /px4_offboard/visualizer path_clearing_timeout -1.0
+```

--- a/px4_offboard/visualizer.py
+++ b/px4_offboard/visualizer.py
@@ -122,7 +122,7 @@ class PX4Visualizer(Node):
         self.last_local_pos_update = 0.0
         # time after which existing path is cleared upon receiving new
         # local position ROS2 message
-        self.declare_parameter("path_clearing_timeout_ms", -1)
+        self.declare_parameter("path_clearing_timeout", -1.0)
 
         timer_period = 0.05  # seconds
         self.timer = self.create_timer(timer_period, self.cmdloop_callback)
@@ -135,17 +135,17 @@ class PX4Visualizer(Node):
         self.vehicle_attitude[3] = -msg.q[3]
 
     def vehicle_local_position_callback(self, msg):
-        path_clearing_timeout_ms = (
-            self.get_parameter("path_clearing_timeout_ms")
+        path_clearing_timeout = (
+            self.get_parameter("path_clearing_timeout")
             .get_parameter_value()
-            .integer_value
+            .double_value
         )
-        if path_clearing_timeout_ms >= 0 and (
-            (Clock().now().nanoseconds / 1e6 - self.last_local_pos_update)
-            > path_clearing_timeout_ms
+        if path_clearing_timeout >= 0 and (
+            (Clock().now().nanoseconds / 1e9 - self.last_local_pos_update)
+            > path_clearing_timeout
         ):
             self.vehicle_path_msg.poses.clear()
-        self.last_local_pos_update = Clock().now().nanoseconds / 1e6
+        self.last_local_pos_update = Clock().now().nanoseconds / 1e9
 
         # TODO: handle NED->ENU transformation
         self.vehicle_local_position[0] = msg.x


### PR DESCRIPTION
Visualization node and RVIZ2 launch command can stay alive in separate shell while restarting SITL in another without persistence of old path that was drawn for previous SITL run. This way one can iterate custom algorithms designs in other nodes/packages while keeping RVIZ2 on the screen with easy STIL re-running using custom command, if one needs to (for instance with `gz` simulator setting `HEADLESS=1` or other available options. They can be set with environment variables but this solution works for me better, and maybe will for somebody else as well. Please let me know if You find my solution helpful or if it needs modifications to make it even better :)

I tested this particular commit's changes by compiling package, running visualization node using launch file with command below:
```sh
ros2 launch px4_offboard visualize.launch.py
```
Upon restarting PX4 SITL GZ simulation in another shell path from previous run was successfully removed and frame indicator restarted to base pose.