### PR TITLE
Feature: optional namespace argument

### DIFF
--- a/launch/offboard_hardware_position_control.launch.py
+++ b/launch/offboard_hardware_position_control.launch.py
@@ -36,6 +36,8 @@ __author__ = "Jaeyoung Lim"
 __contact__ = "jalim@ethz.ch"
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
@@ -43,12 +45,26 @@ import os
 
 def generate_launch_description():
     package_dir = get_package_share_directory('px4_offboard')
+
+    # Declare the namespace argument (it can be provided when launching)
+    namespace = LaunchConfiguration('namespace', default='px4_offboard')
+
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'namespace',
+            default_value='px4_offboard',
+            description='Namespace of the nodes'
+        ),
         Node(
             package='px4_offboard',
-            namespace='px4_offboard',
+            namespace=namespace,
             executable='offboard_control',
             name='control',
-            parameters= [{'radius': 2.0},{'altitude': 3.0},{'omega': 0.5}]
+            parameters= [
+                {'radius': 2.0},
+                {'altitude': 3.0},
+                {'omega': 0.5},
+                {'namespace': namespace}
+            ]
         )
     ])

--- a/launch/offboard_position_control.launch.py
+++ b/launch/offboard_position_control.launch.py
@@ -36,15 +36,15 @@ __author__ = "Jaeyoung Lim"
 __contact__ = "jalim@ethz.ch"
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
+import tempfile
 
 
 def generate_launch_description():
-    package_dir = get_package_share_directory('px4_offboard')
 
     # Declare the namespace argument (it can be provided when launching)
     namespace = LaunchConfiguration('namespace', default='px4_offboard')
@@ -76,11 +76,41 @@ def generate_launch_description():
                 {'namespace': namespace}
             ]
         ),
+        OpaqueFunction(function=launch_setup),
+    ])
+
+def patch_rviz_config(original_config_path, namespace):
+    """
+    Patch the RViz configuration file to replace the namespace placeholder with the actual namespace.
+    """
+    with open(original_config_path, 'r') as f:
+        content = f.read()
+
+    # Replace placeholder with actual namespace
+    content = content.replace('__NS__', f'/{namespace}' if namespace else '')
+    
+    # Write to temporary file
+    tmp_rviz_config = tempfile.NamedTemporaryFile(delete=False, suffix='.rviz')
+    tmp_rviz_config.write(content.encode('utf-8'))
+    tmp_rviz_config.close()
+
+    return tmp_rviz_config.name
+
+
+def launch_setup(context, *args, **kwargs):
+    """
+    Function to set up the launch context and patch the RViz configuration.
+    """
+    namespace = LaunchConfiguration('namespace').perform(context)
+    rviz_config_path = os.path.join(get_package_share_directory('px4_offboard'), 'visualize.rviz')
+    patched_config = patch_rviz_config(rviz_config_path, namespace)
+
+    return [
         Node(
             package='rviz2',
             namespace='',
             executable='rviz2',
             name='rviz2',
-            arguments=['-d', [os.path.join(package_dir, 'visualize.rviz')]]
+            arguments=['-d', patched_config]
         )
-    ])
+    ]

--- a/launch/offboard_position_control.launch.py
+++ b/launch/offboard_position_control.launch.py
@@ -36,6 +36,8 @@ __author__ = "Jaeyoung Lim"
 __contact__ = "jalim@ethz.ch"
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
@@ -43,19 +45,36 @@ import os
 
 def generate_launch_description():
     package_dir = get_package_share_directory('px4_offboard')
+
+    # Declare the namespace argument (it can be provided when launching)
+    namespace = LaunchConfiguration('namespace', default='px4_offboard')
+
     return LaunchDescription([
-        Node(
-            package='px4_offboard',
-            namespace='px4_offboard',
-            executable='visualizer',
-            name='visualizer'
+        DeclareLaunchArgument(
+            'namespace',
+            default_value='px4_offboard',
+            description='Namespace of the nodes'
         ),
         Node(
             package='px4_offboard',
-            namespace='px4_offboard',
+            namespace=namespace,
+            executable='visualizer',
+            name='visualizer',
+            parameters=[
+                {'namespace': namespace}
+            ]
+        ),
+        Node(
+            package='px4_offboard',
+            namespace=namespace,
             executable='offboard_control',
             name='control',
-            parameters= [{'radius': 10.0},{'altitude': 5.0},{'omega': 0.5}]
+            parameters= [
+                {'radius': 10.0},
+                {'altitude': 5.0},
+                {'omega': 0.5},
+                {'namespace': namespace}
+            ]
         ),
         Node(
             package='rviz2',

--- a/launch/visualize.launch.py
+++ b/launch/visualize.launch.py
@@ -36,15 +36,15 @@ __author__ = "Jaeyoung Lim"
 __contact__ = "jalim@ethz.ch"
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
+import tempfile
 
 
 def generate_launch_description():
-    package_dir = get_package_share_directory('px4_offboard')
 
     # Declare the namespace argument (it can be provided when launching)
     namespace = LaunchConfiguration('namespace', default='px4_offboard')
@@ -64,11 +64,41 @@ def generate_launch_description():
                 {'namespace': namespace}
             ]
         ),
+        OpaqueFunction(function=launch_setup),
+    ])
+
+def patch_rviz_config(original_config_path, namespace):
+    """
+    Patch the RViz configuration file to replace the namespace placeholder with the actual namespace.
+    """
+    with open(original_config_path, 'r') as f:
+        content = f.read()
+
+    # Replace placeholder with actual namespace
+    content = content.replace('__NS__', f'/{namespace}' if namespace else '')
+    
+    # Write to temporary file
+    tmp_rviz_config = tempfile.NamedTemporaryFile(delete=False, suffix='.rviz')
+    tmp_rviz_config.write(content.encode('utf-8'))
+    tmp_rviz_config.close()
+
+    return tmp_rviz_config.name
+
+
+def launch_setup(context, *args, **kwargs):
+    """
+    Function to set up the launch context and patch the RViz configuration.
+    """
+    namespace = LaunchConfiguration('namespace').perform(context)
+    rviz_config_path = os.path.join(get_package_share_directory('px4_offboard'), 'visualize.rviz')
+    patched_config = patch_rviz_config(rviz_config_path, namespace)
+
+    return [
         Node(
             package='rviz2',
             namespace='',
             executable='rviz2',
             name='rviz2',
-            arguments=['-d', [os.path.join(package_dir, 'visualize.rviz')]]
+            arguments=['-d', patched_config]
         )
-    ])
+    ]

--- a/launch/visualize.launch.py
+++ b/launch/visualize.launch.py
@@ -36,6 +36,8 @@ __author__ = "Jaeyoung Lim"
 __contact__ = "jalim@ethz.ch"
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
@@ -43,12 +45,24 @@ import os
 
 def generate_launch_description():
     package_dir = get_package_share_directory('px4_offboard')
+
+    # Declare the namespace argument (it can be provided when launching)
+    namespace = LaunchConfiguration('namespace', default='px4_offboard')
+
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'namespace',
+            default_value='px4_offboard',
+            description='Namespace of the nodes'
+        ),
         Node(
             package='px4_offboard',
-            namespace='px4_offboard',
+            namespace=namespace,
             executable='visualizer',
-            name='visualizer'
+            name='visualizer',
+            parameters=[
+                {'namespace': namespace}
+            ]
         ),
         Node(
             package='rviz2',

--- a/px4_offboard/offboard_control.py
+++ b/px4_offboard/offboard_control.py
@@ -50,20 +50,34 @@ class OffboardControl(Node):
 
     def __init__(self):
         super().__init__('minimal_publisher')
-        qos_profile = QoSProfile(
-            reliability=QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
-            durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-            history=QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
-            depth=1
+
+        # Declare and retrieve the namespace parameter
+        self.declare_parameter('namespace', '')  # Default to empty namespace
+        self.namespace = self.get_parameter('namespace').value
+        self.namespace_prefix = f'/{self.namespace}' if self.namespace else ''
+        
+                # QoS profiles
+        qos_profile_pub = QoSProfile(
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            depth=0
+        )
+
+        qos_profile_sub = QoSProfile(
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            durability=QoSDurabilityPolicy.VOLATILE,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            depth=0
         )
 
         self.status_sub = self.create_subscription(
             VehicleStatus,
-            '/fmu/out/vehicle_status_v1',
+            f'{self.namespace_prefix}/fmu/out/vehicle_status',
             self.vehicle_status_callback,
-            qos_profile)
-        self.publisher_offboard_mode = self.create_publisher(OffboardControlMode, '/fmu/in/offboard_control_mode', qos_profile)
-        self.publisher_trajectory = self.create_publisher(TrajectorySetpoint, '/fmu/in/trajectory_setpoint', qos_profile)
+            qos_profile_sub)
+        self.publisher_offboard_mode = self.create_publisher(OffboardControlMode, f'{self.namespace_prefix}/fmu/in/offboard_control_mode', qos_profile_pub)
+        self.publisher_trajectory = self.create_publisher(TrajectorySetpoint, f'{self.namespace_prefix}/fmu/in/trajectory_setpoint', qos_profile_pub)
         timer_period = 0.02  # seconds
         self.timer = self.create_timer(timer_period, self.cmdloop_callback)
         self.dt = timer_period

--- a/resource/visualize.rviz
+++ b/resource/visualize.rviz
@@ -64,7 +64,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /px4_visualizer/vehicle_pose
+        Value: __NS__/px4_visualizer/vehicle_pose
       Value: true
     - Class: rviz_default_plugins/Marker
       Enabled: true
@@ -76,7 +76,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /px4_visualizer/vehicle_velocity
+        Value: __NS__/px4_visualizer/vehicle_velocity
       Value: true
     - Alpha: 1
       Buffer Length: 1
@@ -103,7 +103,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /px4_visualizer/vehicle_path
+        Value: __NS__/px4_visualizer/vehicle_path
       Value: true
     - Alpha: 1
       Buffer Length: 1
@@ -130,7 +130,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /px4_visualizer/setpoint_path
+        Value: __NS__/px4_visualizer/setpoint_path
       Value: true
   Enabled: true
   Global Options:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     maintainer_email='jalim@ethz.ch',
     description='TODO: Package description',
     license='TODO: License declaration',
-    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
                 'offboard_control = px4_offboard.offboard_control:main',


### PR DESCRIPTION
### **Add optional namespace argument to launch file**

This update introduces an optional `namespace` argument to the launch process, enabling support for multi-vehicle setups.

#### **Usage**

```bash
ros2 launch px4_offboard offboard_position_control.launch.py namespace:=<namespace>
```

This will result in namespaced topics such as:

```
/<namespace>/px4_visualizer/vehicle_pose
```

If no `namespace` argument is provided, the launch behaves as before, using:

```
/px4_visualizer/vehicle_pose
```

The `visualize.rviz` config is also dynamically updated to reflect the selected namespace by replacing the `__NS__` placeholder.

**Minor update:** Removed `tests_require` from `setup.py`, as it is no longer supported by `setuptools`.
