### PR TITLE
Improved namespaces for subscribers and publishers

### DIFF
--- a/px4_offboard/offboard_control.py
+++ b/px4_offboard/offboard_control.py
@@ -49,11 +49,6 @@ class OffboardControl(Node):
 
     def __init__(self):
         super().__init__('minimal_publisher')
-
-        # Declare and retrieve the namespace parameter
-        self.declare_parameter('namespace', '')  # Default to empty namespace
-        self.namespace = self.get_parameter('namespace').value
-        self.namespace_prefix = f'/{self.namespace}' if self.namespace else ''
         
                 # QoS profiles
         qos_profile_pub = QoSProfile(
@@ -72,11 +67,11 @@ class OffboardControl(Node):
 
         self.status_sub = self.create_subscription(
             VehicleStatus,
-            f'{self.namespace_prefix}/fmu/out/vehicle_status',
+            'fmu/out/vehicle_status',
             self.vehicle_status_callback,
             qos_profile_sub)
-        self.publisher_offboard_mode = self.create_publisher(OffboardControlMode, f'{self.namespace_prefix}/fmu/in/offboard_control_mode', qos_profile_pub)
-        self.publisher_trajectory = self.create_publisher(TrajectorySetpoint, f'{self.namespace_prefix}/fmu/in/trajectory_setpoint', qos_profile_pub)
+        self.publisher_offboard_mode = self.create_publisher(OffboardControlMode, 'fmu/in/offboard_control_mode', qos_profile_pub)
+        self.publisher_trajectory = self.create_publisher(TrajectorySetpoint, 'fmu/in/trajectory_setpoint', qos_profile_pub)
         timer_period = 0.02  # seconds
         self.timer = self.create_timer(timer_period, self.cmdloop_callback)
         self.dt = timer_period

--- a/px4_offboard/visualizer.py
+++ b/px4_offboard/visualizer.py
@@ -53,11 +53,6 @@ class PX4Visualizer(Node):
     def __init__(self):
         super().__init__("visualizer")
 
-        # Declare and retrieve the namespace parameter
-        self.declare_parameter('namespace', '')  # Default to empty namespace
-        self.namespace = self.get_parameter('namespace').value
-        self.namespace_prefix = f'/{self.namespace}' if self.namespace else ''
-
         # QoS profiles
         qos_profile_pub = QoSProfile(
             reliability=QoSReliabilityPolicy.BEST_EFFORT,
@@ -75,34 +70,34 @@ class PX4Visualizer(Node):
 
         self.attitude_sub = self.create_subscription(
             VehicleAttitude,
-            f"{self.namespace_prefix}/fmu/out/vehicle_attitude",
+            "fmu/out/vehicle_attitude",
             self.vehicle_attitude_callback,
             qos_profile_sub,
         )
         self.local_position_sub = self.create_subscription(
             VehicleLocalPosition,
-            f"{self.namespace_prefix}/fmu/out/vehicle_local_position",
+            "fmu/out/vehicle_local_position",
             self.vehicle_local_position_callback,
             qos_profile_sub,
         )
         self.setpoint_sub = self.create_subscription(
             TrajectorySetpoint,
-            f"{self.namespace_prefix}/fmu/in/trajectory_setpoint",
+            "fmu/in/trajectory_setpoint",
             self.trajectory_setpoint_callback,
             qos_profile_sub,
         )
 
         self.vehicle_pose_pub = self.create_publisher(
-            PoseStamped, f"{self.namespace_prefix}/px4_visualizer/vehicle_pose", 10
+            PoseStamped, "px4_visualizer/vehicle_pose", 10
         )
         self.vehicle_vel_pub = self.create_publisher(
-            Marker, f"{self.namespace_prefix}/px4_visualizer/vehicle_velocity", 10
+            Marker, "px4_visualizer/vehicle_velocity", 10
         )
         self.vehicle_path_pub = self.create_publisher(
-            Path, f"{self.namespace_prefix}/px4_visualizer/vehicle_path", 10
+            Path, "px4_visualizer/vehicle_path", 10
         )
         self.setpoint_path_pub = self.create_publisher(
-            Path, f"{self.namespace_prefix}/px4_visualizer/setpoint_path", 10
+            Path, "px4_visualizer/setpoint_path", 10
         )
 
         self.vehicle_attitude = np.array([1.0, 0.0, 0.0, 0.0])


### PR DESCRIPTION
This is a small fix to remove some redundancy in the way that name-spaces are defined.
The default behavior of a ros2 `Node` is that it takes an argument `namespace` and puts it before any subscriber and publisher if there is no initial `/`. For example, if you define the subscriber path as `fmu/in/vehicle` and you pass `namespace=pop` in the launch file, it will resort to `/pop/fmu/in/vehicle`.

The current implementation has the same behavior but with extra lines as it explicitly extracts a namespace launch argument.