### PR TITLE
Remove default namespace

### DIFF
--- a/launch/offboard_hardware_position_control.launch.py
+++ b/launch/offboard_hardware_position_control.launch.py
@@ -47,12 +47,12 @@ def generate_launch_description():
     package_dir = get_package_share_directory('px4_offboard')
 
     # Declare the namespace argument (it can be provided when launching)
-    namespace = LaunchConfiguration('namespace', default='px4_offboard')
+    namespace = LaunchConfiguration('namespace')
 
     return LaunchDescription([
         DeclareLaunchArgument(
             'namespace',
-            default_value='px4_offboard',
+            default_value='',
             description='Namespace of the nodes'
         ),
         Node(

--- a/launch/offboard_position_control.launch.py
+++ b/launch/offboard_position_control.launch.py
@@ -47,12 +47,12 @@ import tempfile
 def generate_launch_description():
 
     # Declare the namespace argument (it can be provided when launching)
-    namespace = LaunchConfiguration('namespace', default='px4_offboard')
+    namespace = LaunchConfiguration('namespace')
 
     return LaunchDescription([
         DeclareLaunchArgument(
             'namespace',
-            default_value='px4_offboard',
+            default_value='',
             description='Namespace of the nodes'
         ),
         Node(


### PR DESCRIPTION
**Summary**

This PR aligns the default naming convention of the offboard nodes with the Micro-XRCE-DDS-Agent. By removing the default namespace from offboard nodes, we ensure out-of-the-box compatibility with the agent's default configuration (which publishes under no namespace).

**Changes**

- Removed default namespace: Offboard nodes no longer default to a specific namespace upon initialization. 

Flexibility is still maintained. Users can pass a custom namespace via the namespace launch argument if their specific architecture requires it.