### PR TITLE
Update Python offboard startup sequence for current PX4 ROS 2

### DIFF
--- a/px4_offboard/offboard_control.py
+++ b/px4_offboard/offboard_control.py
@@ -38,31 +38,31 @@ __contact__ = "jalim@ethz.ch"
 import rclpy
 import numpy as np
 from rclpy.node import Node
-from rclpy.qos import QoSProfile, QoSReliabilityPolicy, QoSHistoryPolicy, QoSDurabilityPolicy
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSHistoryPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
 
 from px4_msgs.msg import OffboardControlMode
 from px4_msgs.msg import TrajectorySetpoint
+from px4_msgs.msg import VehicleCommand
 from px4_msgs.msg import VehicleStatus
 
 
 class OffboardControl(Node):
 
     def __init__(self):
-        super().__init__('minimal_publisher')
+        super().__init__('offboard_control')
 
-                # QoS profiles
-        qos_profile_pub = QoSProfile(
-            reliability=QoSReliabilityPolicy.BEST_EFFORT,
-            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
-            history=QoSHistoryPolicy.KEEP_LAST,
-            depth=0
-        )
+        # Match the official PX4 example's depth-10 publisher QoS. A non-zero
+        # depth is required with KEEP_LAST and avoids the ROS 2 Jazzy warning.
+        qos_profile_pub = QoSProfile(depth=10)
 
         qos_profile_sub = QoSProfile(
             reliability=QoSReliabilityPolicy.BEST_EFFORT,
             durability=QoSDurabilityPolicy.VOLATILE,
             history=QoSHistoryPolicy.KEEP_LAST,
-            depth=0
+            depth=10
         )
 
         self.status_sub = self.create_subscription(
@@ -70,14 +70,13 @@ class OffboardControl(Node):
             'fmu/out/vehicle_status',
             self.vehicle_status_callback,
             qos_profile_sub)
-        self.status_sub = self.create_subscription(
-            VehicleStatus,
-            'fmu/out/vehicle_status_v1',
-            self.vehicle_status_callback,
-            qos_profile_sub)
-        self.publisher_offboard_mode = self.create_publisher(OffboardControlMode, 'fmu/in/offboard_control_mode', qos_profile_pub)
-        self.publisher_trajectory = self.create_publisher(TrajectorySetpoint, 'fmu/in/trajectory_setpoint', qos_profile_pub)
-        timer_period = 0.02  # seconds
+        self.publisher_offboard_mode = self.create_publisher(
+            OffboardControlMode, 'fmu/in/offboard_control_mode', qos_profile_pub)
+        self.publisher_trajectory = self.create_publisher(
+            TrajectorySetpoint, 'fmu/in/trajectory_setpoint', qos_profile_pub)
+        self.publisher_vehicle_command = self.create_publisher(
+            VehicleCommand, 'fmu/in/vehicle_command', qos_profile_pub)
+        timer_period = 0.1  # seconds; 10 Hz, as in the official PX4 example
         self.timer = self.create_timer(timer_period, self.cmdloop_callback)
         self.dt = timer_period
         self.declare_parameter('radius', 10.0)
@@ -85,8 +84,9 @@ class OffboardControl(Node):
         self.declare_parameter('altitude', 5.0)
         self.nav_state = VehicleStatus.NAVIGATION_STATE_MAX
         self.arming_state = VehicleStatus.ARMING_STATE_DISARMED
-        # Note: no parameter callbacks are used to prevent sudden inflight changes of radii and omega
-        # which would result in large discontinuities in setpoints
+        self.offboard_setpoint_counter = 0
+        # No parameter callbacks are used to prevent sudden inflight changes of
+        # radius and omega, which would cause large setpoint discontinuities.
         self.theta = 0.0
         self.radius = self.get_parameter('radius').value
         self.omega = self.get_parameter('omega').value
@@ -94,28 +94,64 @@ class OffboardControl(Node):
 
     def vehicle_status_callback(self, msg):
         # TODO: handle NED->ENU transformation
-        print("NAV_STATUS: ", msg.nav_state)
-        print("  - offboard status: ", VehicleStatus.NAVIGATION_STATE_OFFBOARD)
         self.nav_state = msg.nav_state
         self.arming_state = msg.arming_state
 
     def cmdloop_callback(self):
-        # Publish offboard control modes
+        if self.offboard_setpoint_counter == 10:
+            # PX4 custom main mode 6 is Offboard. Send only after ten complete
+            # heartbeat/setpoint cycles have established the offboard stream.
+            self.publish_vehicle_command(
+                VehicleCommand.VEHICLE_CMD_DO_SET_MODE, 1.0, 6.0)
+            self.publish_vehicle_command(
+                VehicleCommand.VEHICLE_CMD_COMPONENT_ARM_DISARM, 1.0)
+            self.get_logger().info('Offboard mode and arm commands sent')
+
+        self.publish_offboard_control_mode()
+        self.publish_trajectory_setpoint()
+
+        if self.offboard_setpoint_counter < 11:
+            self.offboard_setpoint_counter += 1
+
+        # Keep the initial setpoint fixed during startup. Once PX4 confirms both
+        # Offboard and armed, advance it around the circle.
+        if (self.nav_state == VehicleStatus.NAVIGATION_STATE_OFFBOARD and
+                self.arming_state == VehicleStatus.ARMING_STATE_ARMED):
+            self.theta += self.omega * self.dt
+
+    def publish_offboard_control_mode(self):
         offboard_msg = OffboardControlMode()
         offboard_msg.timestamp = int(self.get_clock().now().nanoseconds / 1000)
-        offboard_msg.position=True
-        offboard_msg.velocity=False
-        offboard_msg.acceleration=False
+        offboard_msg.position = True
+        offboard_msg.velocity = False
+        offboard_msg.acceleration = False
+        offboard_msg.attitude = False
+        offboard_msg.body_rate = False
+        offboard_msg.thrust_and_torque = False
+        offboard_msg.direct_actuator = False
         self.publisher_offboard_mode.publish(offboard_msg)
-        if (self.nav_state == VehicleStatus.NAVIGATION_STATE_OFFBOARD and self.arming_state == VehicleStatus.ARMING_STATE_ARMED):
 
-            trajectory_msg = TrajectorySetpoint()
-            trajectory_msg.position[0] = self.radius * np.cos(self.theta)
-            trajectory_msg.position[1] = self.radius * np.sin(self.theta)
-            trajectory_msg.position[2] = -self.altitude
-            self.publisher_trajectory.publish(trajectory_msg)
+    def publish_trajectory_setpoint(self):
+        trajectory_msg = TrajectorySetpoint()
+        trajectory_msg.timestamp = int(self.get_clock().now().nanoseconds / 1000)
+        trajectory_msg.position[0] = self.radius * np.cos(self.theta)
+        trajectory_msg.position[1] = self.radius * np.sin(self.theta)
+        trajectory_msg.position[2] = -self.altitude
+        trajectory_msg.yaw = 0.0
+        self.publisher_trajectory.publish(trajectory_msg)
 
-            self.theta = self.theta + self.omega * self.dt
+    def publish_vehicle_command(self, command, param1=0.0, param2=0.0):
+        command_msg = VehicleCommand()
+        command_msg.timestamp = int(self.get_clock().now().nanoseconds / 1000)
+        command_msg.param1 = param1
+        command_msg.param2 = param2
+        command_msg.command = command
+        command_msg.target_system = 1
+        command_msg.target_component = 1
+        command_msg.source_system = 1
+        command_msg.source_component = 1
+        command_msg.from_external = True
+        self.publisher_vehicle_command.publish(command_msg)
 
 
 def main(args=None):

--- a/px4_offboard/offboard_control.py
+++ b/px4_offboard/offboard_control.py
@@ -113,10 +113,9 @@ class OffboardControl(Node):
         if self.offboard_setpoint_counter < 11:
             self.offboard_setpoint_counter += 1
 
-        # Keep the initial setpoint fixed during startup. Once PX4 confirms both
-        # Offboard and armed, advance it around the circle.
-        if (self.nav_state == VehicleStatus.NAVIGATION_STATE_OFFBOARD and
-                self.arming_state == VehicleStatus.ARMING_STATE_ARMED):
+        # Keep the initial setpoint fixed during startup, then advance it around
+        # the circle without depending on optional return telemetry.
+        if self.offboard_setpoint_counter >= 11:
             self.theta += self.omega * self.dt
 
     def publish_offboard_control_mode(self):

--- a/px4_offboard/offboard_control.py
+++ b/px4_offboard/offboard_control.py
@@ -93,7 +93,6 @@ class OffboardControl(Node):
         self.altitude = self.get_parameter('altitude').value
 
     def vehicle_status_callback(self, msg):
-        # TODO: handle NED->ENU transformation
         self.nav_state = msg.nav_state
         self.arming_state = msg.arming_state
 


### PR DESCRIPTION
Updates the Python offboard controller to follow the current PX4 ROS 2 example:

- Stream heartbeat and trajectory setpoints before requesting Offboard mode.
- Wait for 10 setpoint cycles before switching modes and arming.
- Publish the required VehicleCommand messages.
- Continue publishing while executing the existing circular trajectory.
- Add trajectory timestamps and initialize current control-mode fields.
- Use Jazzy-compatible QoS depths, eliminating the depth-zero warning.
- Remove obsolete status-dependent trajectory gating and stale comments.

This preserves the existing circular-flight and visualization behavior while enabling automatic Offboard entry and arming in current PX4 SITL.